### PR TITLE
add customizable Prompt for the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ or when [running the docker image](#using-the-ready-made-docker-image) or when c
 | PLUGINS              | no       | `graph-plugin, image-plugin` | The enabled plugins of the bot. By default all plugins (grpah-plugin and image-plugin) are enabled.                                                                                                |
 | DEBUG_LEVEL          | no       | `TRACE`                      | a debug level used for logging activity, defaults to `INFO`                                                                                                                                        |
 | BOT_CONTEXT_MSG      | no       | `15`                         | The number of previous messages which are appended to the conversation with ChatGPT, defaults to 100                                                                                               |
+| BOT_INSTRUCTION      | no       | `Act like Elon Musk`         | Extra instruction to give your assistance. How should the assistant behave? |
 
 > **Note**
 > The `YFILES_SERVER_URL` is used for automatically converting text information created by the bot into diagrams.

--- a/helm/chatgpt-mattermost-bot/templates/chatbot-config.yaml
+++ b/helm/chatgpt-mattermost-bot/templates/chatbot-config.yaml
@@ -17,5 +17,4 @@ data:
   DEBUG_LEVEL: "{{ .Values.config.DEBUG_LEVEL | default "INFO"  }}"
   BOT_CONTEXT_MSG: "{{ .Values.config.BOT_CONTEXT_MSG | default "100"  }}"
   NODE_ENV: "{{ .Values.config.NODE_ENV | default "production"  }}"
-
-
+  BOT_INSTRUCTION: "{{ .Values.config.BOT_INSTRUCTION | default ""  }}"

--- a/helm/chatgpt-mattermost-bot/values.yaml
+++ b/helm/chatgpt-mattermost-bot/values.yaml
@@ -26,6 +26,7 @@ config:                   #   required:   example:                    descriptio
   DEBUG_LEVEL: ""         #   no	        TRACE	                      a debug level used for logging activity, defaults to INFO
   BOT_CONTEXT_MSG: ""     #   no	        15	                        The number of previous messages which are appended to the conversation with ChatGPT, defaults to 100
   NODE_ENV: ""            #   no          development                 The mode NodeJS runs in. Defaults to production
+  BOT_INSTRUCTION: ""     #   no          Act like Elon Musk          Extra instruction to give your assistance. How should the assistant behave?
 
 
 serviceAccount:

--- a/helm/chatgpt-mattermost-bot/values.yaml
+++ b/helm/chatgpt-mattermost-bot/values.yaml
@@ -3,7 +3,7 @@ image:
   repository: chatgpt-mattermost-bot
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.1.2"
+  tag: ""
 
 imagePullSecrets: []
 

--- a/src/botservice.ts
+++ b/src/botservice.ts
@@ -20,6 +20,9 @@ if (!global.FormData) {
 
 const name = process.env['MATTERMOST_BOTNAME'] || '@chatgpt'
 const contextMsgCount = Number(process.env['BOT_CONTEXT_MSG'] ?? 100)
+const additionalBotInstructions = process.env['BOT_INSTRUCTION'] || "You are a helpful assistant. Whenever users asks you for help you will " +
+    "provide them with succinct answers formatted using Markdown. You know the user's name as it is provided within the " +
+    "meta data of the messages."
 
 /* List of all registered plugins */
 const plugins: PluginBase<any>[] = [
@@ -30,9 +33,8 @@ const plugins: PluginBase<any>[] = [
 ]
 
 /* The main system instruction for GPT */
-const botInstructions = "Your name is " + name + " and you are a helpful assistant. Whenever users asks you for help you will " +
-    "provide them with succinct answers formatted using Markdown. You know the user's name as it is provided within the " +
-    "meta data of the messages."
+const botInstructions = "Your name is " + name + ". " + additionalBotInstructions
+botLog.debug({botInstructions: botInstructions})
 
 async function onClientMessage(msg: WebSocketMessage<JSONMessageData>, meId: string) {
     if (msg.event !== 'posted' || !meId) {


### PR DESCRIPTION
From https://github.com/yGuy/chatgpt-mattermost-bot/issues/62

Adds the possibility to customize the bot by adding a custom prompt.
The env variable for this is called `BOT_INSTRUCTION`

The change is also reflected to the Helm chart.

IMPORTANT: the Helm chart needs to be updated with the new version of the container that is built here:
https://github.com/yGuy/chatgpt-mattermost-bot/blob/c6e547125f7bfb24efe14ac990ee05dbac5d6564/helm/chatgpt-mattermost-bot/Chart.yaml#L5 to the Version without "v" ( ex 2.2.0 )

and here:
https://github.com/yGuy/chatgpt-mattermost-bot/blob/c6e547125f7bfb24efe14ac990ee05dbac5d6564/helm/chatgpt-mattermost-bot/Chart.yaml#L6 to match the image tag ( ex. v2.2.0 )

This needs to be done by the repository maintainer as there is no way for me to know how the next image is tagged